### PR TITLE
Legacy UDP port status detection algorithm support

### DIFF
--- a/portlist.cc
+++ b/portlist.cc
@@ -775,6 +775,9 @@ int PortList::nextIgnoredState(int prevstate) {
  * ports in that state. */
 bool PortList::isIgnoredState(int state, int *count) {
 
+#if 1
+  return false;
+#else
   int tmp_count = 0;
   if (o.debugging > 2)
     return false;
@@ -809,6 +812,7 @@ bool PortList::isIgnoredState(int state, int *count) {
     return true;
 
   return false;
+#endif
 }
 
 int PortList::numIgnoredStates() {


### PR DESCRIPTION
This patch provides the following custom functionality:
- Legacy UDP port detection: performs post processing on UDP port results to determine if an OPEN|FILTERED response should be considered OPEN or FILTERED based on the ratio of closed UDP ports compared to UDP ports which had responded. (see **output.cc**)
- Allow logging for all port statuses (see **portlist.cc**)